### PR TITLE
Fix overload types for run and spawn

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+import { BoundEffect, Effect } from './types';
+
+export const isBoundEffect = (effect: Effect<any, any, any>): effect is BoundEffect<any, any, any> => {
+  return effect instanceof BoundEffect;
+};

--- a/src/test-app/sagas/user-sagas.ts
+++ b/src/test-app/sagas/user-sagas.ts
@@ -2,6 +2,8 @@ import { forEvery, forLatest, AppEnv } from '../sagas';
 import { userSelected, userLoaded, setCount } from '../actions';
 import { getSelectedUserId, getUserById, getCount } from '../selectors';
 import { loadUser, sleep } from '../app-library';
+import { BoundEffect, SagaEnvironment } from '../../lib';
+import { AppState } from '../types';
 // import { withEnv } from '../../lib/environment';
 
 /**
@@ -39,13 +41,19 @@ export const watchForUserSelectToLoad = forLatest(userSelected, async ($, { id }
 //   export const watchForUserSelectLatest = forLatest(userSelected, watchForUserSelect.saga);
 //
 
-export const increaseCounter = ($: AppEnv) => {
+export const increaseCounter = ($: AppEnv, num: number): void => {
   const count = $.select(getCount);
   console.error(`about to set new count:`, count + 1);
 
   $.dispatch(setCount({ count: count + 1 }));
   // console.error(`count set`, select(getCount));
 };
+
+class ApiCall extends BoundEffect<AppState, [number], number> {
+  run(env: SagaEnvironment<AppState>, num: number) {
+    return 5;
+  }
+}
 
 export const watchForUserSelectorToCountIfNotChangedWithing3s = forLatest(userSelected, async ($, payload) => {
   // console.error(env);
@@ -56,7 +64,9 @@ export const watchForUserSelectorToCountIfNotChangedWithing3s = forLatest(userSe
 
   console.error(`sleep done`);
 
-  await $.run(increaseCounter);
+  await $.run(increaseCounter,87);
+
+  await $.spawn(new ApiCall(9));
 });
 
 export const watchForUserSelectorToCountImmediately = forEvery(


### PR DESCRIPTION
I wasn't able to get the types working without overloads for `run` and `spawn`.
Right now the types for those functions need to be duplicated in the different environments.

Additionally, this makes the Type names and orders more consistent.