### PR TITLE
[fix] Added missing types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Typesafe and lightweight way to write functions with asynchronous side-effects that are easily testable.",
   "main": "compiled/lib/index.js",
+  "types": "compiled/lib/index.d.ts",
   "repository": "https://github.com/tp/tsaga.git",
   "author": "Timm Preetz <timm@preetz.us>",
   "license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
This adds the `types` path inside the `package.json` as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)