### PR TITLE
[fix] Export timeout error

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,3 +3,4 @@ export { Saga, SagaEnvironment, AnySaga, Task } from './types';
 export { createTypedForEvery, createTypedForLatest } from './createTypedWatchers';
 export { expectSaga } from './testing';
 export { testSagaWithState, calls, runs, selects, spawns, dispatches } from './stateBasedTestHelper';
+export { default as TimeoutError } from './TimeoutError';


### PR DESCRIPTION
The `TimeoutError` should be exported to be able to check for inside a `catch` block or the error handler