### PR TITLE
Reorder expect saga calls

### DIFF
--- a/src/compilationSamples/__tests__/__snapshots__/expectSaga.test.ts.snap
+++ b/src/compilationSamples/__tests__/__snapshots__/expectSaga.test.ts.snap
@@ -24,9 +24,16 @@ Array [
   Property 'text' is missing in type '{ notText: string; }' but required in type '{ text: string; }'.",
   },
   Object {
-    "character": 24,
+    "character": 6,
     "fileName": "expectSaga-test.ts",
     "line": 65,
+    "message": "Argument of type 'Response' is not assignable to parameter of type 'string | Request'.
+  Type 'Response' is missing the following properties from type 'Request': context, method, redirect, referrer, and 5 more.",
+  },
+  Object {
+    "character": 24,
+    "fileName": "expectSaga-test.ts",
+    "line": 73,
     "message": "Type 'string' is not assignable to type 'number'.",
   },
 ]

--- a/src/compilationSamples/__tests__/__snapshots__/expectSaga.test.ts.snap
+++ b/src/compilationSamples/__tests__/__snapshots__/expectSaga.test.ts.snap
@@ -11,17 +11,17 @@ Array [
     Property 'text' is missing in type 'CountReducerState' but required in type '{ text: string; }'.",
   },
   Object {
-    "character": 54,
+    "character": 53,
     "fileName": "expectSaga-test.ts",
     "line": 55,
     "message": "Argument of type '5' is not assignable to parameter of type 'boolean'.",
   },
   Object {
-    "character": 19,
+    "character": 20,
     "fileName": "expectSaga-test.ts",
     "line": 56,
-    "message": "Argument of type 'Response' is not assignable to parameter of type 'string | Request'.
-  Type 'Response' is missing the following properties from type 'Request': context, method, redirect, referrer, and 5 more.",
+    "message": "Argument of type 'Action<{ notText: string; }>' is not assignable to parameter of type 'Action<{ text: string; }>'.
+  Property 'text' is missing in type '{ notText: string; }' but required in type '{ text: string; }'.",
   },
   Object {
     "character": 24,

--- a/src/compilationSamples/__tests__/expectSaga.test.ts
+++ b/src/compilationSamples/__tests__/expectSaga.test.ts
@@ -6,5 +6,5 @@ test('expectSaga forces compiler errors when invalid types are used', async () =
   expect(diagnostics).toMatchSnapshot();
 
   // explicit alignment with comments in file, to catch accidental snapshot overwrite
-  expect(diagnostics.length).toBe(4);
+  expect(diagnostics.length).toBe(5);
 });

--- a/src/compilationSamples/samples/expectSaga-test.ts
+++ b/src/compilationSamples/samples/expectSaga-test.ts
@@ -30,7 +30,7 @@ export const stringLongerThanCountSelector = createSelector(
 
 const createActionCreator = actionCreatorFactory('User');
 const postText = createActionCreator<{ text: string }>('set_count');
-const wrongAction = createActionCreator<{ notText: string }>('asdfasdfasdfasfd');
+const wrongAction = createActionCreator<{ notText: string }>('inapt_test_action');
 
 const forEvery = createTypedForEvery<CountReducerState>();
 
@@ -54,9 +54,17 @@ test('Saga test', async () => {
   expectSaga(watchForPostText)
     .withReducer(sampleIdentityCountReducer)
     .andMocks([select(stringLongerThanCountSelector, 5 /* should be `boolean` */)])
-    .whenDispatched(wrongAction({ notText: 'asdf' }))
-    .toCall(fetch, new Response(undefined, { status: 200 }))
-    .toCall(fetch, 404)
+    .whenDispatched(wrongAction({ notText: 'asdf' })) /* should be action with `text` property */
+    .toHaveFinalState({ count: '1' /* should be `number` */ })
+    .run();
+
+  expectSaga(watchForPostText)
+    .withReducer(sampleIdentityCountReducer)
+    .whenDispatched(postText({ text: 'asdf' }))
+    .toCall(
+      fetch,
+      new Response(undefined, { status: 200 }),
+    ) /* should error as `Response` is not a `string` or `Request` */
     .toHaveFinalState({ count: '1' /* should be `number` */ })
     .run();
 

--- a/src/compilationSamples/samples/expectSaga-test.ts
+++ b/src/compilationSamples/samples/expectSaga-test.ts
@@ -53,16 +53,16 @@ const watchForPostText = forEvery(postText, async ($, { text }) => {
 test('Saga test', async () => {
   expectSaga(watchForPostText)
     .withReducer(sampleIdentityCountReducer)
-    .withMocks([select(stringLongerThanCountSelector, 5 /* should be `boolean` */)])
+    .andMocks([select(stringLongerThanCountSelector, 5 /* should be `boolean` */)])
+    .whenDispatched(wrongAction({ notText: 'asdf' }))
     .toCall(fetch, new Response(undefined, { status: 200 }))
     .toCall(fetch, 404)
-    .dispatch(wrongAction({ notText: 'asdf' }))
     .toHaveFinalState({ count: '1' /* should be `number` */ })
     .run();
 
   return expectSaga(watchForPostText)
     .withReducer(sampleIdentityCountReducer)
-    .dispatch(postText({ text: 'asdf' }))
+    .whenDispatched(postText({ text: 'asdf' }))
     .toHaveFinalState({ count: '1' /* should be `number` */ })
     .run();
 });

--- a/src/lib/testing/expect-saga.ts
+++ b/src/lib/testing/expect-saga.ts
@@ -52,10 +52,7 @@ interface AssertionStage<State> {
    * @param effect
    * @param args The arguments the effect should be called with.
    */
-  toRun<Args extends any[], Return>(
-    effect: SagaFunc<State, Args, Return>,
-    ...args: Args
-  ): AssertionStage<State>;
+  toRun<Args extends any[], Return>(effect: SagaFunc<State, Args, Return>, ...args: Args): AssertionStage<State>;
 
   /**
    * Expect the bound function to spawn another bound function.
@@ -64,10 +61,7 @@ interface AssertionStage<State> {
    * @param effect
    * @param args The arguments the effect should be called with.
    */
-  toSpawn<Args extends any[], Return>(
-    effect: SagaFunc<State, Args, Return>,
-    ...args: Args
-  ): AssertionStage<State>;
+  toSpawn<Args extends any[], Return>(effect: SagaFunc<State, Args, Return>, ...args: Args): AssertionStage<State>;
 
   /**
    * Expect an action to be dispatched.
@@ -145,10 +139,7 @@ class SagaTest<State, Payload>
     return this;
   }
 
-  public toCall<Args extends any[], Return>(
-    func: (...args: Args) => Return,
-    ...args: Args
-  ): AssertionStage<State> {
+  public toCall<Args extends any[], Return>(func: (...args: Args) => Return, ...args: Args): AssertionStage<State> {
     this.asserts.push({
       type: 'call',
       func,
@@ -157,10 +148,7 @@ class SagaTest<State, Payload>
 
     return this;
   }
-  public toRun<Args extends any[], Return>(
-    func: SagaFunc<State, Args, Return>,
-    ...args: Args
-  ): AssertionStage<State> {
+  public toRun<Args extends any[], Return>(func: SagaFunc<State, Args, Return>, ...args: Args): AssertionStage<State> {
     this.asserts.push({
       type: 'run',
       func,

--- a/src/lib/testing/expect-saga.ts
+++ b/src/lib/testing/expect-saga.ts
@@ -23,7 +23,7 @@ interface WithMocksStage<State, Payload> extends WhenDispatchedStage<State, Payl
    *
    * @param mocks The array of mocks to be used by the bound function.
    */
-  withMocks(mocks: Mocks<State>): WhenDispatchedStage<State, Payload>;
+  andMocks(mocks: Mocks<State>): WhenDispatchedStage<State, Payload>;
 }
 
 interface WhenDispatchedStage<State, Payload> {
@@ -133,7 +133,7 @@ class SagaTest<State, Payload>
     return this;
   }
 
-  public withMocks(mocks: Mocks<State>): WhenDispatchedStage<State, Payload> {
+  public andMocks(mocks: Mocks<State>): WhenDispatchedStage<State, Payload> {
     this.mocks = mocks;
 
     return this;

--- a/src/test-app/__tests__/expectSaga.test.ts
+++ b/src/test-app/__tests__/expectSaga.test.ts
@@ -12,9 +12,9 @@ nock.disableNetConnect();
 test('Test helper with mocked sleep call', () => {
   return expectSaga(watchForUserSelectorToCountIfNotChangedWithing3s)
     .withReducer(userReducer)
-    .withMocks([call(sleep, Promise.resolve())])
+    .andMocks([call(sleep, Promise.resolve())])
+    .whenDispatched(userSelected({ id: 2 }))
     .toCall(sleep, 3000)
-    .dispatch(userSelected({ id: 2 }))
     .toHaveFinalState({ count: 1, selectedUser: 2, usersById: {} })
     .run();
 }, 500 /* something below the 3s sleep */);
@@ -22,9 +22,9 @@ test('Test helper with mocked sleep call', () => {
 test('Test helper with mocked select', async () => {
   return expectSaga(watchForUserSelectorToCountIfNotChangedWithing3s)
     .withReducer(userReducer)
-    .withMocks([call(sleep, Promise.resolve()), select(getCount, 5)])
+    .andMocks([call(sleep, Promise.resolve()), select(getCount, 5)])
+    .whenDispatched(userSelected({ id: 2 }))
     .toCall(sleep, 3000)
-    .dispatch(userSelected({ id: 2 }))
     .toHaveFinalState({ count: 6, selectedUser: 2, usersById: {} })
     .run();
 }, 500 /* something below the 3s sleep */);
@@ -32,10 +32,10 @@ test('Test helper with mocked select', async () => {
 test('Test helper asserting on message', async () => {
   return expectSaga(watchForUserSelectorToCountIfNotChangedWithing3s)
     .withReducer(userReducer)
-    .withMocks([call(sleep, Promise.resolve()), select(getCount, 5)])
+    .andMocks([call(sleep, Promise.resolve()), select(getCount, 5)])
+    .whenDispatched(userSelected({ id: 2 }))
     .toCall(sleep, 3000)
     .toDispatch(setCount({ count: 6 }))
-    .dispatch(userSelected({ id: 2 }))
     .toHaveFinalState({ count: 6, selectedUser: 2, usersById: {} })
     .run();
 }, 500 /* something below the 3s sleep */);
@@ -44,10 +44,10 @@ test("Test helper asserting on message, fails of message doesn't match", async (
   try {
     await expectSaga(watchForUserSelectorToCountIfNotChangedWithing3s)
       .withReducer(userReducer)
-      .withMocks([call(sleep, Promise.resolve())])
+      .andMocks([call(sleep, Promise.resolve())])
+      .whenDispatched(userSelected({ id: 2 }))
       .toCall(sleep, 3000)
       .toDispatch(setCount({ count: 9999 }))
-      .dispatch(userSelected({ id: 2 }))
       .toHaveFinalState({ count: 6, selectedUser: 2, usersById: {} })
       .run();
   } catch (e) {


### PR DESCRIPTION
This reorder the calls in which you need to test to be aligned with `expectBoundFunction`