### PR TITLE
feat(scaffold): change console error to warn to reduce alert noise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsaga",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Typesafe and lightweight way to write functions with asynchronous side-effects that are easily testable.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/lib/CancellationToken.ts
+++ b/src/lib/CancellationToken.ts
@@ -3,7 +3,7 @@ export class CancellationToken {
   private _canceled = false;
 
   public cancel() {
-    console.error(`cancelling via token`);
+    console.warn(`cancelling via token`);
     this._canceled = true;
   }
 


### PR DESCRIPTION
this console error creates a lot of noise in the alerts.
Just a warning would be enough and is a quick win without refactoring legacy code